### PR TITLE
Update debug-shell.sh for today's k8s (1.22 here)

### DIFF
--- a/debug-shell/debug-shell.sh
+++ b/debug-shell/debug-shell.sh
@@ -2,4 +2,8 @@
 
 IMAGE=${1:-centos:latest}
 
-kubectl run -n ${KUBECTL_PLUGINS_CURRENT_NAMESPACE} -it --rm --restart=Never kube-shell --image ${IMAGE} -- bash
+# This has been modified to work with the post 1.12 extended plugin model
+# Also attach=true causes kubectl to not die out complaining about --rm
+# in spite of the fact that -i is supposed to set attach=true?
+
+kubectl run --attach=true -it --rm --restart=Never kube-shell --image ${IMAGE} -- bash


### PR DESCRIPTION
the debug-shell.sh script has been changed to fix the following:

* the post 1.12 extended plugin model no longer sets the ENV var that was previously expected for the namespace
* somewhere along the line, `--rm` is throwing errors if you do not pass `attach=true` even though per the manpage, 
  -i is supposed to set `attach=true`